### PR TITLE
Fix katex font

### DIFF
--- a/css/preview.css
+++ b/css/preview.css
@@ -468,7 +468,7 @@
 	z-index: 9999;
 }
 
-#preview.text-markdown * {
+#preview.text-markdown {
 	font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
 }
 


### PR DESCRIPTION
Fix #112
Fix #168

The font of katex spans gets overwritten by a rule in `preview.css`. I fixed it by applying said rule to the preview container only. Font settings will be inherited to all children anyways.

## Before
![Screenshot 2021-09-21 at 12-23-00 test md - Dateien - Nextcloud](https://user-images.githubusercontent.com/1479486/134155261-cda829a6-5a18-406b-b27a-b061fcc6a54f.png)

## After
![Screenshot 2021-09-21 at 12-21-58 test md - Dateien - Nextcloud](https://user-images.githubusercontent.com/1479486/134155265-6656cbe7-be0f-458f-856d-b1d2b0d5eac6.png)
