### PR TITLE
Bump max version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<description><![CDATA[Markdown Editor extends the Nextcloud text editor with a live preview for markdown files.
 
 A full list of features can be found [in the README](https://github.com/icewind1991/files_markdown)]]></description>
-	<version>2.4.1</version>
+	<version>2.4.2</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 
@@ -44,6 +44,6 @@ A full list of features can be found [in the README](https://github.com/icewind1
 	</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="25" max-version="27"/>
+		<nextcloud min-version="25" max-version="28"/>
 	</dependencies>
 </info>


### PR DESCRIPTION
Bumping max version as I haven't noticed any problems with using the app in 28.

Similar request to https://github.com/nextcloud/files_texteditor/pull/846 with similar reason.

The one thing I have noticed, but I am unsure where the issue lies, whether with this app or Deck, is that clicking the checkboxes in a Deck card's description have not worked, though I am unsure when this began.

EDIT: Just saw #218. Converting to draft. And doing more testing. It seems this is broken now, and clicking on a markdown file immediately downloads it.